### PR TITLE
Extract I2C calls to private methods to eliminate duplication

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,14 +88,7 @@ where
     /// let latest_decibel_val = pa_spl.get_latest_decibel().unwrap();
     /// ```
     pub fn get_latest_decibel(&mut self) -> Result<u8, Error<E>> {
-        let mut buffer = [0; 1];
-        self.i2c
-            .as_mut()
-            .ok_or(Error::NoI2cInstance)?
-            .write_read(DEVICE_ADDR, &[DECIBEL_REGISTER], &mut buffer)
-            .map_err(Error::I2c)?;
-
-        Ok(buffer[0])
+        self.read_byte(DECIBEL_REGISTER)
     }
 
     /// Gets the 32-bit device ID from registers ID3-ID0.
@@ -143,14 +136,7 @@ where
     /// let firmware_version = pa_spl.get_firmware_version().unwrap();
     /// ```
     pub fn get_firmware_version(&mut self) -> Result<u8, Error<E>> {
-        let mut buffer = [0; 1];
-        self.i2c
-            .as_mut()
-            .ok_or(Error::NoI2cInstance)?
-            .write_read(DEVICE_ADDR, &[VER_REGISTER], &mut buffer)
-            .map_err(Error::I2c)?;
-
-        Ok(buffer[0])
+        self.read_byte(VER_REGISTER)
     }
 
     /// Gets the value stored in the scratch register.
@@ -167,14 +153,7 @@ where
     /// let val = pa_spl.get_scratch().unwrap();
     /// ```
     pub fn get_scratch(&mut self) -> Result<u8, Error<E>> {
-        let mut buffer = [0; 1];
-        self.i2c
-            .as_mut()
-            .ok_or(Error::NoI2cInstance)?
-            .write_read(DEVICE_ADDR, &[SCRATCH_REGISTER], &mut buffer)
-            .map_err(Error::I2c)?;
-
-        Ok(buffer[0])
+        self.read_byte(SCRATCH_REGISTER)
     }
 
     /// Sets the value stored in the scratch register.
@@ -202,7 +181,7 @@ where
             .expect("I2C instance has already been taken")
     }
 
-    /// Writes a single byte to an I2C register.
+    /// Writes a single byte to an I2C register of the device.
     fn write_byte(&mut self, reg: u8, value: u8) -> Result<(), Error<E>> {
         self.i2c
             .as_mut()
@@ -211,8 +190,16 @@ where
             .map_err(Error::I2c)
     }
 
-    // Reads a single byte from an I2C register.
-    //
+    // Reads a single byte from an I2C register of the device.
+    fn read_byte(&mut self, reg: u8) -> Result<u8, Error<E>> {
+        let mut buffer = [0; 1];
+        self.i2c
+            .as_mut()
+            .ok_or(Error::NoI2cInstance)?
+            .write_read(DEVICE_ADDR, &[reg], &mut buffer)
+            .map_err(Error::I2c)?;
+        Ok(buffer[0])
+    }
 
     // Reads multiple bytes beginning at a start address.
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -192,19 +192,29 @@ where
     /// let result = pa_spl.set_scratch(scratch_val);
     /// ```
     pub fn set_scratch(&mut self, value: u8) -> Result<(), Error<E>> {
-        self.i2c
-            .as_mut()
-            .ok_or(Error::NoI2cInstance)?
-            .write(DEVICE_ADDR, &[SCRATCH_REGISTER, value])
-            .map_err(Error::I2c)
+        self.write_byte(SCRATCH_REGISTER, value)
     }
 
     /// Destroys this driver and releases the I2C bus.
-    pub fn destroy(mut self) -> I2C {
+    pub fn destroy(&mut self) -> I2C {
         self.i2c
             .take()
             .expect("I2C instance has already been taken")
     }
+
+    /// Writes a single byte to an I2C register.
+    fn write_byte(&mut self, reg: u8, value: u8) -> Result<(), Error<E>> {
+        self.i2c
+            .as_mut()
+            .ok_or(Error::NoI2cInstance)?
+            .write(DEVICE_ADDR, &[reg, value])
+            .map_err(Error::I2c)
+    }
+
+    // Reads a single byte from an I2C register.
+    //
+
+    // Reads multiple bytes beginning at a start address.
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,8 @@
 #![cfg_attr(not(test), no_std)]
 
+// extern crate alloc;
+
+// use alloc::vec::Vec;
 use embedded_hal::blocking::i2c;
 
 /// PCB Artists SPL Module I2C address.
@@ -107,11 +110,7 @@ where
     ///
     pub fn get_device_id(&mut self) -> Result<u32, Error<E>> {
         let mut buffer: [u8; 4] = [0; 4];
-        self.i2c
-            .as_mut()
-            .ok_or(Error::NoI2cInstance)?
-            .write_read(DEVICE_ADDR, &[DEVICE_ID_REGISTERS[0]], &mut buffer)
-            .map_err(Error::I2c)?;
+        self.read_bytes(DEVICE_ID_REGISTERS[0], &mut buffer)?;
 
         // Combine the bytes into a u32.
         let device_id: u32 = ((buffer[0] as u32) << 24)
@@ -190,7 +189,7 @@ where
             .map_err(Error::I2c)
     }
 
-    // Reads a single byte from an I2C register of the device.
+    /// Reads a single byte from an I2C register of the device.
     fn read_byte(&mut self, reg: u8) -> Result<u8, Error<E>> {
         let mut buffer = [0; 1];
         self.i2c
@@ -201,7 +200,15 @@ where
         Ok(buffer[0])
     }
 
-    // Reads multiple bytes beginning at a start address.
+    /// Read multiple bytes from a starting register.
+    fn read_bytes(&mut self, start_reg: u8, buffer: &mut [u8]) -> Result<(), Error<E>> {
+        self.i2c
+            .as_mut()
+            .ok_or(Error::NoI2cInstance)?
+            .write_read(DEVICE_ADDR, &[start_reg], buffer)
+            .map_err(Error::I2c)?;
+        Ok(())
+    }
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,5 @@
 #![cfg_attr(not(test), no_std)]
 
-// extern crate alloc;
-
-// use alloc::vec::Vec;
 use embedded_hal::blocking::i2c;
 
 /// PCB Artists SPL Module I2C address.


### PR DESCRIPTION
## Summary
<!-- 

1. In one sentence, or as close as possible, summarize why the changes are
needed. Then, include any relevant links, such as Slack discussions or design
documents. 

2. In one sentence, or as close as possible, summarize how the changes achieve
the resolution of the issue.

3. Specify the number of the issue resolved by this PR below.

-->

The I2C reads and writes follow the same patterns and were repeated throughout the driver methods.

The duplicated code for reading and writing single a single byte and reading multiple bytes has been extracted to private methods. Calls to the private methods have been swapped into the public methods. 

- resolves #36 

## Details
<!-- 

Describe the specific changes that have been made in this pull request. Provide
details on the approach taken to address the problem and any notable
implementation details. 

If the changes have visual elements or supporting visuals, like a change to a
user interface or images of signals on a scope, including screenshots or GIFs
can help reviewers understand them more easily. 

Also include any additional information that might be needed for verification
and validation.

-->

No additional details.

## Testing
<!--

Describe how the changes have been tested and how to reproduce the test results.

If no tests or testing is necessary, briefly state why.

-->

This was a pure refactor, so no new tests were needed. 

## Checklist

- [x] I have added or updated doc comments for my code changes.
- [x] I have added or updated comments to difficult-to-understand code.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings or errors.
